### PR TITLE
Fix AddressType state for contract creation info

### DIFF
--- a/src/components/address/AddressType.tsx
+++ b/src/components/address/AddressType.tsx
@@ -9,8 +9,8 @@ interface AddressTypeProps {
 }
 
 export function AddressType({ isContract, address }: AddressTypeProps) {
-  const [contractCreator] = useState<string | null>(null);
-  const [creationTx] = useState<string | null>(null);
+  const [contractCreator, setContractCreator] = useState<string | null>(null);
+  const [creationTx, setCreationTx] = useState<string | null>(null);
   const [contractCode, setContractCode] = useState<string | null>(null);
   const [loading, setLoading] = useState<boolean>(false);
   const [error, setError] = useState<string | null>(null);
@@ -24,14 +24,14 @@ export function AddressType({ isContract, address }: AddressTypeProps) {
         setError(null);
         
         // Get the transaction history for this address to find the contract creation
-        // const history =  [] //await provider.getHistory(address);
-        
-        // // The first transaction in the history should be the contract creation
-        // if (history && history.length > 0) {
-        //   const creationTransaction = history[0];
-        //   setCreationTx(creationTransaction.hash);
-        //   setContractCreator(creationTransaction.from);
-        // }
+        const history = await provider.getHistory(address);
+
+        // The first transaction in the history should be the contract creation
+        if (history && history.length > 0) {
+          const creationTransaction = history[0];
+          setCreationTx(creationTransaction.hash);
+          setContractCreator(creationTransaction.from);
+        }
       } catch (err) {
         console.error("Error fetching contract information:", err);
         setError("Failed to fetch contract information");


### PR DESCRIPTION
## Summary
- allow AddressType component to track contract creator and creation transaction
- fetch contract creation details using `provider.getHistory`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_b_6846d6e43fe0832490d9c210ca3e4e19