### PR TITLE
Add Unit Helper conversion page

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,10 @@ pnpm-debug.log*
 lerna-debug.log*
 
 node_modules
+/.pnp.cjs
+/.pnp.loader.mjs
+/.yarn
+yarn.lock
 dist
 dist-ssr
 *.local

--- a/README.md
+++ b/README.md
@@ -1,5 +1,16 @@
 # React + TypeScript + Vite
 
+This project uses **Yarn** with Plug'n'Play (PnP) for dependency
+management. When running the project scripts make sure to use `yarn`
+instead of `npm`. For example, build the project with:
+
+```bash
+yarn build
+```
+
+Running `npm` directly will fail to resolve dependencies because the
+node modules are managed by PnP.
+
 This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
 
 Currently, two official plugins are available:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "blockchain-explorer",
   "private": true,
+  "packageManager": "yarn@4.9.1",
   "version": "0.0.0",
   "type": "module",
   "scripts": {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { NetworkInfo } from './components/NetworkInfo'
 import { NetworkProvider } from './context/NetworkContext'
 import { WalletProvider } from './context/WalletContext'
 import { KeccakTable } from './components/KeccakTable'
+import { UnitHelper } from './components/UnitHelper'
 
 function App() {
   const [route, setRoute] = useState<string>('blocks')
@@ -92,6 +93,8 @@ function App() {
         return <Profile address={params.address} onBack={navigateToBlocks} />
       case 'keccak':
         return <KeccakTable />
+      case 'helper':
+        return <UnitHelper />
       default:
         return (
           <>

--- a/src/components/BlockTimeConverter.tsx
+++ b/src/components/BlockTimeConverter.tsx
@@ -1,0 +1,93 @@
+import { useState } from "react";
+import { Label } from "./ui/label";
+import { Input } from "./ui/input";
+import { getBlock, provider } from "@/lib/blockchain";
+
+export function BlockTimeConverter() {
+  const [blockNumber, setBlockNumber] = useState("");
+  const [timestamp, setTimestamp] = useState("");
+
+  const handleBlockNumberChange = async (value: string) => {
+    setBlockNumber(value);
+    const num = Number(value);
+    if (!Number.isNaN(num) && value !== "") {
+      try {
+        const block = await getBlock(num);
+        if (block) {
+          setTimestamp(block.timestamp.toString());
+        } else {
+          setTimestamp("");
+        }
+      } catch {
+        setTimestamp("");
+      }
+    } else {
+      setTimestamp("");
+    }
+  };
+
+  const handleTimestampChange = async (value: string) => {
+    setTimestamp(value);
+    const ts = Number(value);
+    if (!Number.isNaN(ts) && value !== "") {
+      try {
+        const latestNumber = await provider.getBlockNumber();
+        let low = 0;
+        let high = latestNumber;
+        let found = -1;
+        while (low <= high) {
+          const mid = Math.floor((low + high) / 2);
+          const b = await provider.getBlock(mid);
+          if (!b) {
+            high = mid - 1;
+            continue;
+          }
+          if (b.timestamp === ts) {
+            found = b.number;
+            break;
+          } else if (b.timestamp < ts) {
+            low = mid + 1;
+          } else {
+            high = mid - 1;
+          }
+        }
+        if (found === -1 && high >= 0) {
+          const b = await provider.getBlock(high);
+          if (b && b.timestamp <= ts) {
+            found = b.number;
+          }
+        }
+        if (found !== -1) {
+          setBlockNumber(found.toString());
+        } else {
+          setBlockNumber("");
+        }
+      } catch {
+        setBlockNumber("");
+      }
+    } else {
+      setBlockNumber("");
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2 text-left">
+        <Label htmlFor="block">Block Number</Label>
+        <Input
+          id="block"
+          value={blockNumber}
+          onChange={(e) => handleBlockNumberChange(e.target.value)}
+        />
+      </div>
+      <div className="space-y-2 text-left">
+        <Label htmlFor="timestamp">Timestamp (sec)</Label>
+        <Input
+          id="timestamp"
+          value={timestamp}
+          onChange={(e) => handleTimestampChange(e.target.value)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/Layout.tsx
+++ b/src/components/Layout.tsx
@@ -58,6 +58,7 @@ export function Layout({ children }: LayoutProps) {
             <a href="#/blocks" className="text-sm font-medium transition-colors hover:text-primary">Blocks</a>
             <a href="#/accounts" className="text-sm font-medium transition-colors hover:text-primary">Accounts</a>
             <a href="#/tokens" className="text-sm font-medium transition-colors hover:text-primary">Tokens</a>
+            <a href="#/helper" className="text-sm font-medium transition-colors hover:text-primary">Helper</a>
             {account && (
               <a href={`#/profile/${account}`} className="text-sm font-medium transition-colors hover:text-primary">Profile</a>
             )}

--- a/src/components/UnitConverter.tsx
+++ b/src/components/UnitConverter.tsx
@@ -1,0 +1,75 @@
+import { useState } from "react";
+import { Label } from "./ui/label";
+import { Input } from "./ui/input";
+import { ethers } from "ethers";
+
+export function UnitConverter() {
+  const [wei, setWei] = useState("");
+  const [gwei, setGwei] = useState("");
+  const [ether, setEther] = useState("");
+
+  const handleWeiChange = (value: string) => {
+    setWei(value);
+    try {
+      const bn = BigInt(value || "0");
+      setGwei(ethers.formatUnits(bn, "gwei"));
+      setEther(ethers.formatEther(bn));
+    } catch {
+      setGwei("");
+      setEther("");
+    }
+  };
+
+  const handleGweiChange = (value: string) => {
+    setGwei(value);
+    try {
+      const bn = ethers.parseUnits(value || "0", "gwei");
+      setWei(bn.toString());
+      setEther(ethers.formatEther(bn));
+    } catch {
+      setWei("");
+      setEther("");
+    }
+  };
+
+  const handleEtherChange = (value: string) => {
+    setEther(value);
+    try {
+      const bn = ethers.parseEther(value || "0");
+      setWei(bn.toString());
+      setGwei(ethers.formatUnits(bn, "gwei"));
+    } catch {
+      setWei("");
+      setGwei("");
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="space-y-2 text-left">
+        <Label htmlFor="wei">Wei</Label>
+        <Input
+          id="wei"
+          value={wei}
+          onChange={(e) => handleWeiChange(e.target.value)}
+        />
+      </div>
+      <div className="space-y-2 text-left">
+        <Label htmlFor="gwei">Gwei</Label>
+        <Input
+          id="gwei"
+          value={gwei}
+          onChange={(e) => handleGweiChange(e.target.value)}
+        />
+      </div>
+      <div className="space-y-2 text-left">
+        <Label htmlFor="ether">Ether</Label>
+        <Input
+          id="ether"
+          value={ether}
+          onChange={(e) => handleEtherChange(e.target.value)}
+        />
+      </div>
+    </div>
+  );
+}

--- a/src/components/UnitHelper.tsx
+++ b/src/components/UnitHelper.tsx
@@ -3,11 +3,14 @@ import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
 import { Input } from "./ui/input";
 import { Label } from "./ui/label";
 import { ethers } from "ethers";
+import { getBlock, provider } from "@/lib/blockchain";
 
 export function UnitHelper() {
   const [wei, setWei] = useState("");
   const [gwei, setGwei] = useState("");
   const [ether, setEther] = useState("");
+  const [blockNumber, setBlockNumber] = useState("");
+  const [timestamp, setTimestamp] = useState("");
 
   const handleWeiChange = (value: string) => {
     setWei(value);
@@ -45,6 +48,69 @@ export function UnitHelper() {
     }
   };
 
+  const handleBlockNumberChange = async (value: string) => {
+    setBlockNumber(value);
+    const num = Number(value);
+    if (!Number.isNaN(num) && value !== "") {
+      try {
+        const block = await getBlock(num);
+        if (block) {
+          setTimestamp(block.timestamp.toString());
+        } else {
+          setTimestamp("");
+        }
+      } catch {
+        setTimestamp("");
+      }
+    } else {
+      setTimestamp("");
+    }
+  };
+
+  const handleTimestampChange = async (value: string) => {
+    setTimestamp(value);
+    const ts = Number(value);
+    if (!Number.isNaN(ts) && value !== "") {
+      try {
+        const latestNumber = await provider.getBlockNumber();
+        let low = 0;
+        let high = latestNumber;
+        let found = -1;
+        while (low <= high) {
+          const mid = Math.floor((low + high) / 2);
+          const b = await provider.getBlock(mid);
+          if (!b) {
+            high = mid - 1;
+            continue;
+          }
+          if (b.timestamp === ts) {
+            found = b.number;
+            break;
+          } else if (b.timestamp < ts) {
+            low = mid + 1;
+          } else {
+            high = mid - 1;
+          }
+        }
+        if (found === -1 && high >= 0) {
+          const b = await provider.getBlock(high);
+          if (b && b.timestamp <= ts) {
+            found = b.number;
+          }
+        }
+        if (found !== -1) {
+          setBlockNumber(found.toString());
+        } else {
+          setBlockNumber("");
+        }
+      } catch {
+        setBlockNumber("");
+      }
+    } else {
+      setBlockNumber("");
+    }
+  };
+
   return (
     <Card>
       <CardHeader>
@@ -74,6 +140,22 @@ export function UnitHelper() {
               id="ether"
               value={ether}
               onChange={(e) => handleEtherChange(e.target.value)}
+            />
+          </div>
+          <div className="space-y-2 text-left">
+            <Label htmlFor="block">Block Number</Label>
+            <Input
+              id="block"
+              value={blockNumber}
+              onChange={(e) => handleBlockNumberChange(e.target.value)}
+            />
+          </div>
+          <div className="space-y-2 text-left">
+            <Label htmlFor="timestamp">Timestamp (sec)</Label>
+            <Input
+              id="timestamp"
+              value={timestamp}
+              onChange={(e) => handleTimestampChange(e.target.value)}
             />
           </div>
         </div>

--- a/src/components/UnitHelper.tsx
+++ b/src/components/UnitHelper.tsx
@@ -1,163 +1,17 @@
-import { useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
-import { Input } from "./ui/input";
-import { Label } from "./ui/label";
-import { ethers } from "ethers";
-import { getBlock, provider } from "@/lib/blockchain";
+import { UnitConverter } from "./UnitConverter";
+import { BlockTimeConverter } from "./BlockTimeConverter";
 
 export function UnitHelper() {
-  const [wei, setWei] = useState("");
-  const [gwei, setGwei] = useState("");
-  const [ether, setEther] = useState("");
-  const [blockNumber, setBlockNumber] = useState("");
-  const [timestamp, setTimestamp] = useState("");
-
-  const handleWeiChange = (value: string) => {
-    setWei(value);
-    try {
-      const bn = BigInt(value || "0");
-      setGwei(ethers.formatUnits(bn, "gwei"));
-      setEther(ethers.formatEther(bn));
-    } catch {
-      setGwei("");
-      setEther("");
-    }
-  };
-
-  const handleGweiChange = (value: string) => {
-    setGwei(value);
-    try {
-      const bn = ethers.parseUnits(value || "0", "gwei");
-      setWei(bn.toString());
-      setEther(ethers.formatEther(bn));
-    } catch {
-      setWei("");
-      setEther("");
-    }
-  };
-
-  const handleEtherChange = (value: string) => {
-    setEther(value);
-    try {
-      const bn = ethers.parseEther(value || "0");
-      setWei(bn.toString());
-      setGwei(ethers.formatUnits(bn, "gwei"));
-    } catch {
-      setWei("");
-      setGwei("");
-    }
-  };
-
-  const handleBlockNumberChange = async (value: string) => {
-    setBlockNumber(value);
-    const num = Number(value);
-    if (!Number.isNaN(num) && value !== "") {
-      try {
-        const block = await getBlock(num);
-        if (block) {
-          setTimestamp(block.timestamp.toString());
-        } else {
-          setTimestamp("");
-        }
-      } catch {
-        setTimestamp("");
-      }
-    } else {
-      setTimestamp("");
-    }
-  };
-
-  const handleTimestampChange = async (value: string) => {
-    setTimestamp(value);
-    const ts = Number(value);
-    if (!Number.isNaN(ts) && value !== "") {
-      try {
-        const latestNumber = await provider.getBlockNumber();
-        let low = 0;
-        let high = latestNumber;
-        let found = -1;
-        while (low <= high) {
-          const mid = Math.floor((low + high) / 2);
-          const b = await provider.getBlock(mid);
-          if (!b) {
-            high = mid - 1;
-            continue;
-          }
-          if (b.timestamp === ts) {
-            found = b.number;
-            break;
-          } else if (b.timestamp < ts) {
-            low = mid + 1;
-          } else {
-            high = mid - 1;
-          }
-        }
-        if (found === -1 && high >= 0) {
-          const b = await provider.getBlock(high);
-          if (b && b.timestamp <= ts) {
-            found = b.number;
-          }
-        }
-        if (found !== -1) {
-          setBlockNumber(found.toString());
-        } else {
-          setBlockNumber("");
-        }
-      } catch {
-        setBlockNumber("");
-      }
-    } else {
-      setBlockNumber("");
-    }
-  };
-
   return (
     <Card>
       <CardHeader>
         <CardTitle className="text-xl">Unit Helper</CardTitle>
       </CardHeader>
       <CardContent>
-        <div className="space-y-4">
-          <div className="space-y-2 text-left">
-            <Label htmlFor="wei">Wei</Label>
-            <Input
-              id="wei"
-              value={wei}
-              onChange={(e) => handleWeiChange(e.target.value)}
-            />
-          </div>
-          <div className="space-y-2 text-left">
-            <Label htmlFor="gwei">Gwei</Label>
-            <Input
-              id="gwei"
-              value={gwei}
-              onChange={(e) => handleGweiChange(e.target.value)}
-            />
-          </div>
-          <div className="space-y-2 text-left">
-            <Label htmlFor="ether">Ether</Label>
-            <Input
-              id="ether"
-              value={ether}
-              onChange={(e) => handleEtherChange(e.target.value)}
-            />
-          </div>
-          <div className="space-y-2 text-left">
-            <Label htmlFor="block">Block Number</Label>
-            <Input
-              id="block"
-              value={blockNumber}
-              onChange={(e) => handleBlockNumberChange(e.target.value)}
-            />
-          </div>
-          <div className="space-y-2 text-left">
-            <Label htmlFor="timestamp">Timestamp (sec)</Label>
-            <Input
-              id="timestamp"
-              value={timestamp}
-              onChange={(e) => handleTimestampChange(e.target.value)}
-            />
-          </div>
+        <div className="space-y-6">
+          <UnitConverter />
+          <BlockTimeConverter />
         </div>
       </CardContent>
     </Card>

--- a/src/components/UnitHelper.tsx
+++ b/src/components/UnitHelper.tsx
@@ -1,0 +1,83 @@
+import { useState } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
+import { Input } from "./ui/input";
+import { Label } from "./ui/label";
+import { ethers } from "ethers";
+
+export function UnitHelper() {
+  const [wei, setWei] = useState("");
+  const [gwei, setGwei] = useState("");
+  const [ether, setEther] = useState("");
+
+  const handleWeiChange = (value: string) => {
+    setWei(value);
+    try {
+      const bn = BigInt(value || "0");
+      setGwei(ethers.formatUnits(bn, "gwei"));
+      setEther(ethers.formatEther(bn));
+    } catch {
+      setGwei("");
+      setEther("");
+    }
+  };
+
+  const handleGweiChange = (value: string) => {
+    setGwei(value);
+    try {
+      const bn = ethers.parseUnits(value || "0", "gwei");
+      setWei(bn.toString());
+      setEther(ethers.formatEther(bn));
+    } catch {
+      setWei("");
+      setEther("");
+    }
+  };
+
+  const handleEtherChange = (value: string) => {
+    setEther(value);
+    try {
+      const bn = ethers.parseEther(value || "0");
+      setWei(bn.toString());
+      setGwei(ethers.formatUnits(bn, "gwei"));
+    } catch {
+      setWei("");
+      setGwei("");
+    }
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-xl">Unit Helper</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="space-y-4">
+          <div className="space-y-2 text-left">
+            <Label htmlFor="wei">Wei</Label>
+            <Input
+              id="wei"
+              value={wei}
+              onChange={(e) => handleWeiChange(e.target.value)}
+            />
+          </div>
+          <div className="space-y-2 text-left">
+            <Label htmlFor="gwei">Gwei</Label>
+            <Input
+              id="gwei"
+              value={gwei}
+              onChange={(e) => handleGweiChange(e.target.value)}
+            />
+          </div>
+          <div className="space-y-2 text-left">
+            <Label htmlFor="ether">Ether</Label>
+            <Input
+              id="ether"
+              value={ether}
+              onChange={(e) => handleEtherChange(e.target.value)}
+            />
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}


### PR DESCRIPTION
## Summary
- add a `UnitHelper` component to convert between Wei/Gwei/Ether
- route `/helper` to the new page
- expose Helper in main navigation

## Testing
- `npm run lint`
- `npm run build` *(fails: Cannot find module 'react')*

------
https://chatgpt.com/codex/tasks/task_b_685633cfe5dc8324bf13c4c52b08f029