### PR TITLE
Remove duplicate formatAddress

### DIFF
--- a/src/components/BlockDetails.tsx
+++ b/src/components/BlockDetails.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
-import { getBlock, getTransaction, formatTimestamp, formatAddress } from "../lib/blockchain";
+import { getBlock, getTransaction, formatTimestamp } from "../lib/blockchain";
+import { formatAddress } from "../lib/format";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
 import { Button } from "./ui/button";
 import {

--- a/src/components/TransactionDetails.tsx
+++ b/src/components/TransactionDetails.tsx
@@ -3,7 +3,8 @@ import { TransactionReceipt, TransactionResponse } from "ethers";
 
 import { Button } from "./ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "./ui/card";
-import { getTransaction, getTransactionReceipt, formatAddress, formatTimestamp } from "../lib/blockchain";
+import { getTransaction, getTransactionReceipt, formatTimestamp } from "../lib/blockchain";
+import { formatAddress } from "../lib/format";
 import { TransactionData } from "./transaction/TransactionData";
 import { TransactionLogs } from "./transaction/TransactionLogs";
 

--- a/src/components/TransactionsList.tsx
+++ b/src/components/TransactionsList.tsx
@@ -1,6 +1,7 @@
 import { TransactionResponse } from "ethers";
 import { useEffect, useState } from "react";
-import { getTransaction, formatAddress } from "../lib/blockchain";
+import { getTransaction } from "../lib/blockchain";
+import { formatAddress } from "../lib/format";
 import { Button } from "./ui/button";
 import { Switch } from "./ui/switch";
 import { Label } from "./ui/label";

--- a/src/lib/blockchain.ts
+++ b/src/lib/blockchain.ts
@@ -107,11 +107,6 @@ export async function getCode(address: string) {
   }
 }
 
-// Function to format address for display
-export function formatAddress(address: string) {
-  if (!address) return "";
-  return `${address.substring(0, 6)}...${address.substring(address.length - 4)}`;
-}
 
 // Function to format timestamp to date
 export function formatTimestamp(timestamp: number) {


### PR DESCRIPTION
## Summary
- centralize `formatAddress` in `src/lib/format.ts`
- remove duplicate implementation from `blockchain.ts`
- update imports in components
- run TypeScript build to verify

## Testing
- `corepack yarn lint && echo "lint complete"`
- `corepack yarn build >/tmp/build.log && tail -n 20 /tmp/build.log`

------
https://chatgpt.com/codex/tasks/task_b_685c22c8ad308324aea643bd751ac4ad